### PR TITLE
Psr2 php cs fixer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ before_script:
   - composer install --no-interaction --prefer-source
 
 script:
+  - vendor/bin/php-cs-fixer fix --config=php_cs.dist --no-interaction
   - vendor/bin/phpunit --configuration phpunit.xml.dist --colors

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5 || ^8"
+        "phpunit/phpunit": "^7.5 || ^8",
+        "friendsofphp/php-cs-fixer": "^2.15"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "require-dev": {
         "phpunit/phpunit": "^7.5 || ^8",
         "phpstan/phpstan-shim": "^0.11",
+        "friendsofphp/php-cs-fixer": "^2.15"
     },
     "autoload": {
         "psr-4": {

--- a/php_cs.dist
+++ b/php_cs.dist
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Rules we follow are from PSR-2 as well as the rectified PSR-2 guide.
+ *
+ * - https://github.com/FriendsOfPHP/PHP-CS-Fixer
+ * - https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
+ * - https://github.com/php-fig-rectified/fig-rectified-standards/blob/master/PSR-2-R-coding-style-guide-additions.md
+ *
+ * If something isn't addressed in either of those, some other common community rules are
+ * used that might not be addressed explicitly in PSR-2 in order to improve code quality
+ * (so that devs don't need to comment on them in Code Reviews).
+ *
+ * For instance: removing trailing white space, removing extra line breaks where
+ * they're not needed (back to back, beginning or end of function/class, etc.),
+ * adding trailing commas in the last line of an array, etc.
+ */
+
+$finder = PhpCsFixer\Finder::create()
+    ->exclude('vendor')
+    ->in(__DIR__);
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@PSR2' => true,
+        'array_syntax' => [ 'syntax' => 'short' ],
+        'binary_operator_spaces' => [ 'align_equals' => false, 'align_double_arrow' => false ],
+        'cast_spaces' => true,
+        'combine_consecutive_unsets' => true,
+        'concat_space' => [ 'spacing' => 'one' ],
+        'linebreak_after_opening_tag' => true,
+        'no_blank_lines_after_class_opening' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'no_extra_consecutive_blank_lines' => true,
+        'no_trailing_comma_in_singleline_array' => true,
+        'no_whitespace_in_blank_line' => true,
+        'no_spaces_around_offset' => true,
+        'no_unused_imports' => true,
+        'no_useless_else' => true,
+        'no_useless_return' => true,
+        'no_whitespace_before_comma_in_array' => true,
+        'normalize_index_brace' => true,
+        'phpdoc_indent' => true,
+        'phpdoc_to_comment' => true,
+        'phpdoc_trim' => true,
+        'single_quote' => true,
+        'ternary_to_null_coalescing' => true,
+        'trailing_comma_in_multiline_array' => true,
+        'trim_array_spaces' => true,
+        'method_argument_space' => ['ensure_fully_multiline' => false],
+        'no_break_comment' => false,
+        'blank_line_before_statement' => true,
+    ])
+    ->setFinder($finder);

--- a/src/Http/Controller/AbstractJsonController.php
+++ b/src/Http/Controller/AbstractJsonController.php
@@ -49,7 +49,7 @@ abstract class AbstractJsonController extends AbstractController
         $response = $controller($request, $route->getVars());
 
         if ($this->isJsonEncodable($response)) {
-            $body     = json_encode($response);
+            $body = json_encode($response);
             $response = $this->responseFactory;
             $response->getBody()->write($body);
         }
@@ -132,7 +132,7 @@ abstract class AbstractJsonController extends AbstractController
                 ResponseInterface $response,
                 HttpException $exception
             ) {
-                $this->response  = $response;
+                $this->response = $response;
                 $this->exception = $exception;
             }
 
@@ -192,7 +192,7 @@ abstract class AbstractJsonController extends AbstractController
                         'code' => 500,
                         'status' => 'error',
                         'message' => $exception->getMessage(),
-                        'data' => []
+                        'data' => [],
                     ]));
 
                     $response = $response

--- a/src/Http/Controller/AbstractRestfulController.php
+++ b/src/Http/Controller/AbstractRestfulController.php
@@ -7,7 +7,6 @@ namespace Wiring\Http\Controller;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-use Wiring\Http\Controller\AbstractJsonController;
 use Wiring\Interfaces\RestfulControllerInterface;
 
 abstract class AbstractRestfulController extends AbstractJsonController implements RestfulControllerInterface
@@ -210,7 +209,7 @@ abstract class AbstractRestfulController extends AbstractJsonController implemen
             'code' => $code,
             'status' => $status,
             'message' => $message,
-            'data' => $data
+            'data' => $data,
         ];
 
         return $result;

--- a/src/Http/Exception/ErrorHandler.php
+++ b/src/Http/Exception/ErrorHandler.php
@@ -70,7 +70,7 @@ class ErrorHandler extends \Exception implements ErrorHandlerInterface
         $this->loggerContext = $loggerContext;
         $this->debug = $debug;
 
-        $msg  = $this->exception->getMessage() ?? 'An error has occurred.';
+        $msg = $this->exception->getMessage() ?? 'An error has occurred.';
         $code = $this->exception->getCode() ?? 0;
 
         parent::__construct($msg, $code, $exception);
@@ -93,7 +93,7 @@ class ErrorHandler extends \Exception implements ErrorHandlerInterface
 
         $type = $this->request->getHeader('Content-Type');
         $mode = $this->request->getHeader('Debug-Mode');
-        $msg  = $this->exception->getMessage() ?? $message;
+        $msg = $this->exception->getMessage() ?? $message;
         $code = $this->exception->getCode() ?? 0;
 
         // Debug mode header
@@ -120,7 +120,7 @@ class ErrorHandler extends \Exception implements ErrorHandlerInterface
                 'code' => $statusCode,
                 'status' => 'error',
                 'message' => $msg,
-                'data' => []
+                'data' => [],
             ];
 
             // Debug mode header
@@ -143,7 +143,7 @@ class ErrorHandler extends \Exception implements ErrorHandlerInterface
         $error = [
             'code' => $statusCode,
             'type' => get_class($this->exception),
-            'message' => $message
+            'message' => $message,
         ];
 
         // Debug mode

--- a/src/Http/Exception/HttpException.php
+++ b/src/Http/Exception/HttpException.php
@@ -50,7 +50,7 @@ class HttpException extends \Exception implements HttpExceptionInterface
         array      $headers = [],
         int        $code = 0
     ) {
-        $this->status  = $status;
+        $this->status = $status;
         $this->message = $message;
         $this->previous = $previous;
         $this->headers = $headers;
@@ -118,7 +118,7 @@ class HttpException extends \Exception implements HttpExceptionInterface
         $this->data = [
             'type' => $this->previous ? get_class($this->previous) : 'error',
             'code' => $statusCode,
-            'message' => $this->message
+            'message' => $this->message,
         ];
 
         $response->withStatus($statusCode);
@@ -151,10 +151,10 @@ class HttpException extends \Exception implements HttpExceptionInterface
 
         if ($response->getBody()->isWritable()) {
             $response->getBody()->write(json_encode([
-                'code'   => $this->status,
+                'code' => $this->status,
                 'status' => 'error',
                 'message' => $this->message,
-                'data' => $data
+                'data' => $data,
             ]));
         }
 

--- a/src/Http/Exception/MethodNotAllowedException.php
+++ b/src/Http/Exception/MethodNotAllowedException.php
@@ -23,7 +23,7 @@ class MethodNotAllowedException extends HttpException
         int        $code = 0
     ) {
         $headers = [
-            'Allow' => implode(', ', $allowed)
+            'Allow' => implode(', ', $allowed),
         ];
 
         parent::__construct(405, $message, $previous, $headers, $code);

--- a/src/Http/Helpers/Console.php
+++ b/src/Http/Helpers/Console.php
@@ -122,7 +122,7 @@ class Console
         }
 
         // Join array elements with a string delimiter
-        $args = implode(",", $data);
+        $args = implode(',', $data);
 
         // Echo to output
         echo "console.assert($args);";
@@ -211,15 +211,15 @@ class Console
         ob_start();
 
         if (is_object($obj)) { // Check is an object
-            $js = "var JSONObject = " . json_encode($obj) . ";\n"
-                . "var JSONString = JSON.stringify(JSONObject);"
-                . "var JSObject = JSON.parse(JSONString); "
+            $js = 'var JSONObject = ' . json_encode($obj) . ";\n"
+                . 'var JSONString = JSON.stringify(JSONObject);'
+                . 'var JSObject = JSON.parse(JSONString); '
                 . "console.$method(JSObject);";
         } elseif (is_array($obj) || $method == 'dirxml') { // Check is an array
-            $js = "var data = " . json_encode($obj) . "; "
+            $js = 'var data = ' . json_encode($obj) . '; '
                 . "console.$method(data);";
         } elseif ($method == 'log') { // Check is set
-            $js = "var data = '"  . $obj . "'; "
+            $js = "var data = '" . $obj . "'; "
                 . "console.$method(data);";
         } else {  // Method is empty
             $js = "console.$method();";

--- a/src/Http/Helpers/Cookie.php
+++ b/src/Http/Helpers/Cookie.php
@@ -32,7 +32,7 @@ class Cookie implements CookieInterface
      */
     public static function set(
         string $name,
-        string $value = "",
+        string $value = '',
         int $expiry = 0,
         bool $secure = false
     ): bool {

--- a/src/Http/Helpers/Info.php
+++ b/src/Http/Helpers/Info.php
@@ -27,7 +27,7 @@ class Info
 
         // Set custom version info
         $ver = sprintf(
-            "PHP Version %s / Wiring Version %s",
+            'PHP Version %s / Wiring Version %s',
             phpversion(),
             APP_VERSION
         );
@@ -36,7 +36,7 @@ class Info
         $exp = [
             '%^.*<body>(.*)</body>.*$%ms' => '$1',
             '/<h1 class="p">(.*?)<\/h1>/i' => '<h1 class="p">' . $ver . '</h1>',
-            '/<img[^>]+\>/i' => '<img src="./img/watermark.png" height="56">'
+            '/<img[^>]+\>/i' => '<img src="./img/watermark.png" height="56">',
         ];
 
         //  Perform a regular expression search and replace

--- a/src/Http/Helpers/Mailer.php
+++ b/src/Http/Helpers/Mailer.php
@@ -39,7 +39,7 @@ class Mailer
 
         $message->body($this->container->get(ViewRendererInterface::class)
             ->render($template, [
-                'data' => $data
+                'data' => $data,
             ]));
 
         call_user_func($callback, $message);

--- a/src/Http/RequestHandler.php
+++ b/src/Http/RequestHandler.php
@@ -146,7 +146,7 @@ class RequestHandler implements RequestHandlerInterface
             return null;
         }
 
-        return $this->middleware[$position]["middleware"];
+        return $this->middleware[$position]['middleware'];
     }
 
     /**
@@ -159,9 +159,9 @@ class RequestHandler implements RequestHandlerInterface
         ?string $key = null
     ): RequestHandler {
         $this->middleware[] = [
-            "key" => $key,
-            "middleware" => $middleware,
-            "after" => true
+            'key' => $key,
+            'middleware' => $middleware,
+            'after' => true,
         ];
 
         return $this;
@@ -177,7 +177,7 @@ class RequestHandler implements RequestHandlerInterface
     protected function findMiddleware(string $key): ?int
     {
         foreach ($this->middleware as $k => $middleware) {
-            if ($middleware["key"] === $key) {
+            if ($middleware['key'] === $key) {
                 return $k;
             }
         }
@@ -191,7 +191,7 @@ class RequestHandler implements RequestHandlerInterface
     protected function executeMiddleware(array $middlewareArray): void
     {
         /** @var MiddlewareInterface $middleware */
-        $middleware = $middlewareArray["middleware"];
+        $middleware = $middlewareArray['middleware'];
 
         $this->response = $middleware->process($this->request, $this);
     }
@@ -254,9 +254,9 @@ class RequestHandler implements RequestHandlerInterface
         ?string $key
     ): RequestHandler {
         $this->middleware[] = [
-            "key" => $key,
-            "middleware" => $middleware,
-            "after" => true
+            'key' => $key,
+            'middleware' => $middleware,
+            'after' => true,
         ];
 
         return $this;

--- a/src/Interfaces/CookieInterface.php
+++ b/src/Interfaces/CookieInterface.php
@@ -27,7 +27,7 @@ interface CookieInterface
      */
     public static function set(
         string $name,
-        string $value = "",
+        string $value = '',
         int $expiry = 0,
         bool $secure = false
     ): bool;

--- a/src/Interfaces/StrategyAwareInterface.php
+++ b/src/Interfaces/StrategyAwareInterface.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Wiring\Interfaces;
 
-use Wiring\Interfaces\StrategyInterface;
-
 interface StrategyAwareInterface
 {
     /**

--- a/src/Interfaces/StrategyInterface.php
+++ b/src/Interfaces/StrategyInterface.php
@@ -9,7 +9,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Wiring\Http\Exception\MethodNotAllowedException;
 use Wiring\Http\Exception\NotFoundException;
-use Wiring\Interfaces\RouteInterface;
 
 interface StrategyInterface
 {

--- a/src/Permissions/Acl/Acl.php
+++ b/src/Permissions/Acl/Acl.php
@@ -34,7 +34,7 @@ class Acl
         foreach ($roles as $role) {
             // Check role instance
             if (!$role instanceof Role) {
-                throw new \InvalidArgumentException("Role is invalid!");
+                throw new \InvalidArgumentException('Role is invalid!');
             }
         }
 
@@ -43,7 +43,7 @@ class Acl
         foreach ($resources as $resource) {
             // Check resource instance
             if (!$resource instanceof Resource) {
-                throw new \InvalidArgumentException("Resource is invalid!");
+                throw new \InvalidArgumentException('Resource is invalid!');
             }
         }
 

--- a/src/Traits/ConfigAwareTrait.php
+++ b/src/Traits/ConfigAwareTrait.php
@@ -65,6 +65,6 @@ trait ConfigAwareTrait
      */
     public function lang($key)
     {
-        return $this->config("lang." . $key);
+        return $this->config('lang.' . $key);
     }
 }


### PR DESCRIPTION
# Changed log
- Reolves issue #16.
- This PR also fixes the coding style via `php-cs-fixer`.
- Add the `php_cs.dist` for the `php-cs-fixer` config.
- The config file defines the `PSR-2` rule and other useful rule settings.