### PR TITLE
Fix classes on tests folder via phpstan level 5

### DIFF
--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -14,14 +14,29 @@ final class ApplicationTest extends TestCase
 {
     public function testInstanceCreated()
     {
-        $container = $this->createMock(ContainerInterface::class);
-        $request = $this->createMock(ServerRequestInterface::class);
-        $response = $this->createMock(ResponseInterface::class);
+        $container = $this->createContainerMock();
+        $request = $this->createServerRequestMock();
+        $response = $this->createResponseMock();
 
         $app = new Application($container, $request, $response);
 
         $this->assertInstanceOf(Application::class, $app);
         $this->assertInstanceOf(ResponseInterface::class, $app->run());
         $this->assertInstanceOf(ResponseInterface::class, $app->stop());
+    }
+
+    private function createContainerMock()
+    {
+        return $this->createMock(ContainerInterface::class);
+    }
+
+    private function createServerRequestMock()
+    {
+        return $this->createMock(ServerRequestInterface::class);
+    }
+
+    private function createResponseMock()
+    {
+        return $this->createMock(ResponseInterface::class);
     }
 }

--- a/tests/Http/Controller/ControllerTest.php
+++ b/tests/Http/Controller/ControllerTest.php
@@ -20,15 +20,15 @@ final class ControllerTest extends TestCase
      */
     public function testSimpleController()
     {
-        $container = $this->createMock(ContainerInterface::class);
+        $container = $this->createContainerMock();
 
-        $view = $this->createMock(ViewStrategyInterface::class);
+        $view = $this->createViewStrategyMock();
 
         $container->method('get')
             ->with(ViewStrategyInterface::class)
             ->willReturn($view);
 
-        $response = $this->createMock(ResponseInterface::class);
+        $response = $this->createResponseMock();
         $response->method('withStatus')
             ->willReturnSelf();
 
@@ -45,15 +45,15 @@ final class ControllerTest extends TestCase
      */
     public function testJsonController()
     {
-        $container = $this->createMock(ContainerInterface::class);
+        $container = $this->createContainerMock();
 
-        $view = $this->createMock(JsonStrategyInterface::class);
+        $view = $this->createJsonStrategyMock();
 
         $container->method('get')
             ->with(JsonStrategyInterface::class)
             ->willReturn($view);
 
-        $response = $this->createMock(ResponseInterface::class);
+        $response = $this->createResponseMock();
         $response->method('withStatus')
             ->willReturnSelf();
 
@@ -63,5 +63,25 @@ final class ControllerTest extends TestCase
         $this->assertInstanceOf(AbstractJsonController::class, $controller);
         $this->assertInstanceOf(JsonStrategyInterface::class, $controller->json());
         $this->assertInstanceOf(ResponseInterface::class, $controller->indexAction());
+    }
+
+    private function createContainerMock()
+    {
+        return $this->createMock(ContainerInterface::class);
+    }
+
+    private function createViewStrategyMock()
+    {
+        return $this->createMock(ViewStrategyInterface::class);
+    }
+
+    private function createResponseMock()
+    {
+        return $this->createMock(ResponseInterface::class);
+    }
+
+    private function createJsonStrategyMock()
+    {
+        return $this->createMock(JsonStrategyInterface::class);
     }
 }

--- a/tests/Http/Exception/ExceptionsTest.php
+++ b/tests/Http/Exception/ExceptionsTest.php
@@ -35,11 +35,11 @@ class ExceptionsTest extends TestCase
         $this->assertInstanceOf(HttpException::class, $exception);
         $this->assertEquals(404, $exception->getStatusCode());
 
-        $stream = $this->createMock(StreamInterface::class);
+        $stream = $this->createStreamMock();
         $stream->method('isWritable')
             ->willReturn(false);
 
-        $response = $this->createMock(ResponseInterface::class);
+        $response = $this->createResponseMock();
         $response->method('withStatus')
             ->willReturnSelf();
         $response->method('withAddedHeader')
@@ -51,5 +51,15 @@ class ExceptionsTest extends TestCase
         $this->assertIsArray($exception->getData());
         $this->assertInstanceOf(ResponseInterface::class, $exception->buildJsonResponse($response));
         $this->assertInstanceOf(ResponseInterface::class, $exception->buildResponse($response));
+    }
+
+    private function createResponseMock()
+    {
+        return $this->createMock(ResponseInterface::class);
+    }
+
+    private function createStreamMock()
+    {
+        return $this->createMock(StreamInterface::class);
     }
 }


### PR DESCRIPTION
# Changed log
- Fix classes on tests folder via `phpstan` level `5`.
- To fix `createMock` method issue, using the `createMethodNameMock` method to return mocked class instead.