### PR TITLE
Add XML declaration to be identified as XML

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"


### PR DESCRIPTION
# Changed log
- Adding the XML declaration because the `phpunit.xml.dist` should be identified as the XML document.
- All XML documents should begin with an XML declaration.