### PR TITLE
Upgrade PHPUnit 8 and organize composer scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,16 +24,14 @@ addons:
 
 before_script:
   - composer self-update
-  - composer require --dev phpunit/phpunit:^7.5 --no-interaction --no-suggest --no-progress
+  - composer require --dev phpunit/phpunit:^8.5 --no-interaction --no-suggest --no-progress
   - composer require --dev phpstan/phpstan:^0.12 --no-interaction --no-suggest --no-progress
   - composer require --dev friendsofphp/php-cs-fixer:^2.16 --no-interaction --no-suggest --no-progress
   - composer require --dev php-coveralls/php-coveralls:^2.2 --no-interaction --no-suggest --no-progress
   - composer install --no-interaction --no-suggest --no-progress
 
 script:
-  - vendor/bin/php-cs-fixer fix --config=php_cs.dist --no-interaction
-  - vendor/bin/phpunit --configuration phpunit.xml.dist --coverage-clover=coverage-report.clover --log-junit=test-report.xml --colors
-  - vendor/bin/phpstan analyse src tests --level=max --no-progress
+  - composer check-all
 
 after_success:
   - vendor/bin/php-coveralls --coverage_clover=coverage-report.clover -v

--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,17 @@
             "@phpunit",
             "@phpstan"
         ],
+        "check-all": [
+            "@php-cs-fixer",
+            "@phpstan",
+            "@phpunit-clover"
+        ],
         "php-cs-fixer": "php-cs-fixer fix --config=php_cs.dist --no-interaction",
         "phpunit": "phpunit --configuration phpunit.xml.dist --coverage-html coverage --colors=always",
+        "phpunit-clover": "phpunit --configuration phpunit.xml.dist --coverage-clover=coverage-report.clover --log-junit=test-report.xml --colors",
         "phpstan": "phpstan analyse src tests --level=max --no-progress --ansi"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^8.5"
     }
 }


### PR DESCRIPTION
# Changed log
- Since this repository requires `php-7.2` version at least, it's nice to update `PHPUnit` version to be `^8.5`.
- Defining `check-all` script with ` "@php-cs-fixer"`, `"@phpstan"` and `"@phpunit-clover"` scripts.
  - And it can use `composer check-all` simply during Travis CI building without running many commands.