### PR TITLE
Using assertSame to make assertion equals strict

### DIFF
--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -82,7 +82,7 @@ final class ApplicationTest extends TestCase
             $this->assertInstanceOf(ResponseInterface::class, $app->handle($request));
         } catch (\Throwable $e) {
             $this->assertInstanceOf(\Exception::class, $e);
-            $this->assertEquals('Bad Request', $e->getMessage());
+            $this->assertSame('Bad Request', $e->getMessage());
         }
 
         try {
@@ -99,7 +99,7 @@ final class ApplicationTest extends TestCase
 
             $app = new Application($container, $request, $response);
         } catch (\Throwable $e) {
-            $this->assertEquals('Function name must be a string', $e->getMessage());
+            $this->assertSame('Function name must be a string', $e->getMessage());
         }
     }
 

--- a/tests/Http/Controller/ControllerTest.php
+++ b/tests/Http/Controller/ControllerTest.php
@@ -66,7 +66,7 @@ final class ControllerTest extends TestCase
             );
         } catch (MethodNotAllowedException $e) {
             $this->assertInstanceOf(MethodNotAllowedException::class, $e);
-            $this->assertEquals('Method Not Allowed', $e->getMessage());
+            $this->assertSame('Method Not Allowed', $e->getMessage());
         }
     }
 

--- a/tests/Http/Exception/ExceptionsTest.php
+++ b/tests/Http/Exception/ExceptionsTest.php
@@ -21,28 +21,28 @@ class ExceptionsTest extends TestCase
         $exception = new BadRequestException();
 
         $this->assertInstanceOf(HttpException::class, $exception);
-        $this->assertEquals(400, $exception->getStatusCode());
+        $this->assertSame(400, $exception->getStatusCode());
 
         $exception = new UnauthorizedException();
 
         $this->assertInstanceOf(HttpException::class, $exception);
-        $this->assertEquals(401, $exception->getStatusCode());
+        $this->assertSame(401, $exception->getStatusCode());
 
         $exception = new MethodNotAllowedException();
 
         $this->assertInstanceOf(HttpException::class, $exception);
-        $this->assertEquals(405, $exception->getStatusCode());
+        $this->assertSame(405, $exception->getStatusCode());
 
         $exception = new NotFoundException();
 
         $this->assertInstanceOf(HttpException::class, $exception);
-        $this->assertEquals(404, $exception->getStatusCode());
+        $this->assertSame(404, $exception->getStatusCode());
 
         // Empty message test
         $exception = new HttpException(0, '', new HttpException(0, ''));
 
         $this->assertInstanceOf(HttpException::class, $exception);
-        $this->assertEquals(0, $exception->getStatusCode());
+        $this->assertSame(0, $exception->getStatusCode());
 
         $stream = $this->createStreamMock();
         $stream->method('isWritable')

--- a/tests/Strategy/JsonStrategyTest.php
+++ b/tests/Strategy/JsonStrategyTest.php
@@ -83,7 +83,7 @@ final class JsonStrategyTest extends TestCase
             );
         } catch (InvalidArgumentException $e) {
             $this->assertInstanceOf(InvalidArgumentException::class, $e);
-            $this->assertEquals('Cannot JSON encode resources', $e->getMessage());
+            $this->assertSame('Cannot JSON encode resources', $e->getMessage());
         }
 
         try {
@@ -95,7 +95,7 @@ final class JsonStrategyTest extends TestCase
             );
         } catch (InvalidArgumentException $e) {
             $this->assertInstanceOf(InvalidArgumentException::class, $e);
-            $this->assertEquals('Unable to encode data to JSON in ' .
+            $this->assertSame('Unable to encode data to JSON in ' .
                 'Wiring\Strategy\JsonStrategy: Malformed UTF-8 characters, ' .
                 'possibly incorrectly encoded', $e->getMessage());
         }

--- a/tests/Traits/TraitsTest.php
+++ b/tests/Traits/TraitsTest.php
@@ -70,7 +70,7 @@ final class TraitsTest extends TestCase
             );
         } catch (Exception $e) {
             $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Auth interface not implemented.', $e->getMessage());
+            $this->assertSame('Auth interface not implemented.', $e->getMessage());
         }
     }
 
@@ -122,7 +122,7 @@ final class TraitsTest extends TestCase
             );
         } catch (Exception $e) {
             $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Config interface not implemented.', $e->getMessage());
+            $this->assertSame('Config interface not implemented.', $e->getMessage());
         }
     }
 
@@ -173,7 +173,7 @@ final class TraitsTest extends TestCase
             );
         } catch (Exception $e) {
             $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Console interface not implemented.', $e->getMessage());
+            $this->assertSame('Console interface not implemented.', $e->getMessage());
         }
     }
 
@@ -194,7 +194,7 @@ final class TraitsTest extends TestCase
             );
         } catch (Exception $e) {
             $this->assertInstanceOf(BadMethodCallException::class, $e);
-            $this->assertEquals('Method get does not exist.', $e->getMessage());
+            $this->assertSame('Method get does not exist.', $e->getMessage());
         }
 
         try {
@@ -204,7 +204,7 @@ final class TraitsTest extends TestCase
             );
         } catch (Exception $e) {
             $this->assertInstanceOf(BadMethodCallException::class, $e);
-            $this->assertEquals('Method has does not exist.', $e->getMessage());
+            $this->assertSame('Method has does not exist.', $e->getMessage());
         }
     }
 
@@ -255,7 +255,7 @@ final class TraitsTest extends TestCase
             );
         } catch (Exception $e) {
             $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Cookie interface not implemented.', $e->getMessage());
+            $this->assertSame('Cookie interface not implemented.', $e->getMessage());
         }
     }
 
@@ -329,7 +329,7 @@ final class TraitsTest extends TestCase
             );
         } catch (Exception $e) {
             $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Database interface not implemented.', $e->getMessage());
+            $this->assertSame('Database interface not implemented.', $e->getMessage());
         }
     }
 
@@ -380,7 +380,7 @@ final class TraitsTest extends TestCase
             );
         } catch (Exception $e) {
             $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Flash interface not implemented.', $e->getMessage());
+            $this->assertSame('Flash interface not implemented.', $e->getMessage());
         }
     }
 
@@ -431,7 +431,7 @@ final class TraitsTest extends TestCase
             );
         } catch (Exception $e) {
             $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Hash interface not implemented.', $e->getMessage());
+            $this->assertSame('Hash interface not implemented.', $e->getMessage());
         }
     }
 
@@ -543,7 +543,7 @@ final class TraitsTest extends TestCase
             );
         } catch (Exception $e) {
             $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Logger interface not implemented.', $e->getMessage());
+            $this->assertSame('Logger interface not implemented.', $e->getMessage());
         }
     }
 
@@ -594,7 +594,7 @@ final class TraitsTest extends TestCase
             );
         } catch (Exception $e) {
             $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Validator interface not implemented.', $e->getMessage());
+            $this->assertSame('Validator interface not implemented.', $e->getMessage());
         }
     }
 
@@ -645,7 +645,7 @@ final class TraitsTest extends TestCase
             );
         } catch (Exception $e) {
             $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Session interface not implemented.', $e->getMessage());
+            $this->assertSame('Session interface not implemented.', $e->getMessage());
         }
     }
 


### PR DESCRIPTION
# Changed log

- Using `assertSame` to make assertion value equals strict.
And it can be good for developers to know current expected and actual values.